### PR TITLE
Rename domain to 17media

### DIFF
--- a/any_tests/jsoniter_any_array_test.go
+++ b/any_tests/jsoniter_any_array_test.go
@@ -3,7 +3,7 @@ package any_tests
 import (
 	"testing"
 
-	"github.com/json-iterator/go"
+	"github.com/17media/jsoniter"
 	"github.com/stretchr/testify/require"
 )
 

--- a/any_tests/jsoniter_any_bool_test.go
+++ b/any_tests/jsoniter_any_bool_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/json-iterator/go"
+	"github.com/17media/jsoniter"
 	"github.com/stretchr/testify/require"
 )
 

--- a/any_tests/jsoniter_any_float_test.go
+++ b/any_tests/jsoniter_any_float_test.go
@@ -3,7 +3,7 @@ package any_tests
 import (
 	"testing"
 
-	"github.com/json-iterator/go"
+	"github.com/17media/jsoniter"
 	"github.com/stretchr/testify/require"
 )
 

--- a/any_tests/jsoniter_any_int_test.go
+++ b/any_tests/jsoniter_any_int_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/json-iterator/go"
+	"github.com/17media/jsoniter"
 	"github.com/stretchr/testify/require"
 )
 

--- a/any_tests/jsoniter_any_map_test.go
+++ b/any_tests/jsoniter_any_map_test.go
@@ -1,7 +1,7 @@
 package any_tests
 
 import (
-	"github.com/json-iterator/go"
+	"github.com/17media/jsoniter"
 	"github.com/stretchr/testify/require"
 	"testing"
 )

--- a/any_tests/jsoniter_any_null_test.go
+++ b/any_tests/jsoniter_any_null_test.go
@@ -1,7 +1,7 @@
 package any_tests
 
 import (
-	"github.com/json-iterator/go"
+	"github.com/17media/jsoniter"
 	"github.com/stretchr/testify/require"
 	"testing"
 )

--- a/any_tests/jsoniter_any_object_test.go
+++ b/any_tests/jsoniter_any_object_test.go
@@ -3,7 +3,7 @@ package any_tests
 import (
 	"testing"
 
-	"github.com/json-iterator/go"
+	"github.com/17media/jsoniter"
 	"github.com/stretchr/testify/require"
 )
 

--- a/any_tests/jsoniter_any_string_test.go
+++ b/any_tests/jsoniter_any_string_test.go
@@ -3,7 +3,7 @@ package any_tests
 import (
 	"testing"
 
-	"github.com/json-iterator/go"
+	"github.com/17media/jsoniter"
 	"github.com/stretchr/testify/require"
 )
 

--- a/any_tests/jsoniter_must_be_valid_test.go
+++ b/any_tests/jsoniter_must_be_valid_test.go
@@ -3,7 +3,7 @@ package any_tests
 import (
 	"testing"
 
-	"github.com/json-iterator/go"
+	"github.com/17media/jsoniter"
 	"github.com/stretchr/testify/require"
 )
 

--- a/any_tests/jsoniter_wrap_test.go
+++ b/any_tests/jsoniter_wrap_test.go
@@ -3,7 +3,7 @@ package any_tests
 import (
 	"testing"
 
-	"github.com/json-iterator/go"
+	"github.com/17media/jsoniter"
 	"github.com/stretchr/testify/require"
 )
 

--- a/api_tests/config_test.go
+++ b/api_tests/config_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/json-iterator/go"
+	"github.com/17media/jsoniter"
 	"github.com/stretchr/testify/require"
 )
 

--- a/api_tests/decoder_test.go
+++ b/api_tests/decoder_test.go
@@ -3,7 +3,7 @@ package test
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/json-iterator/go"
+	"github.com/17media/jsoniter"
 	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"testing"

--- a/api_tests/encoder_18_test.go
+++ b/api_tests/encoder_18_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"unicode/utf8"
 
-	"github.com/json-iterator/go"
+	"github.com/17media/jsoniter"
 	"github.com/stretchr/testify/require"
 )
 

--- a/api_tests/encoder_test.go
+++ b/api_tests/encoder_test.go
@@ -3,7 +3,7 @@ package test
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/json-iterator/go"
+	"github.com/17media/jsoniter"
 	"github.com/stretchr/testify/require"
 	"testing"
 )

--- a/api_tests/marshal_indent_test.go
+++ b/api_tests/marshal_indent_test.go
@@ -2,7 +2,7 @@ package test
 
 import (
 	"encoding/json"
-	"github.com/json-iterator/go"
+	"github.com/17media/jsoniter"
 	"github.com/stretchr/testify/require"
 	"testing"
 )

--- a/api_tests/marshal_json_escape_test.go
+++ b/api_tests/marshal_json_escape_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	jsoniter "github.com/json-iterator/go"
+	jsoniter "github.com/17media/jsoniter"
 	"github.com/stretchr/testify/require"
 )
 

--- a/api_tests/marshal_json_test.go
+++ b/api_tests/marshal_json_test.go
@@ -3,7 +3,7 @@ package test
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/json-iterator/go"
+	"github.com/17media/jsoniter"
 	"testing"
 	"github.com/stretchr/testify/require"
 )

--- a/benchmarks/encode_string_test.go
+++ b/benchmarks/encode_string_test.go
@@ -2,7 +2,7 @@ package test
 
 import (
 	"bytes"
-	"github.com/json-iterator/go"
+	"github.com/17media/jsoniter"
 	"testing"
 )
 

--- a/benchmarks/jsoniter_large_file_test.go
+++ b/benchmarks/jsoniter_large_file_test.go
@@ -2,7 +2,7 @@ package test
 
 import (
 	"encoding/json"
-	"github.com/json-iterator/go"
+	"github.com/17media/jsoniter"
 	"io/ioutil"
 	"os"
 	"testing"

--- a/benchmarks/stream_test.go
+++ b/benchmarks/stream_test.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"testing"
 
-	jsoniter "github.com/json-iterator/go"
+	jsoniter "github.com/17media/jsoniter"
 )
 
 func Benchmark_stream_encode_big_object(b *testing.B) {

--- a/extension_tests/decoder_test.go
+++ b/extension_tests/decoder_test.go
@@ -3,7 +3,7 @@ package test
 import (
 	"bytes"
 	"fmt"
-	"github.com/json-iterator/go"
+	"github.com/17media/jsoniter"
 	"github.com/stretchr/testify/require"
 	"strconv"
 	"testing"

--- a/extension_tests/extension_test.go
+++ b/extension_tests/extension_test.go
@@ -1,7 +1,7 @@
 package test
 
 import (
-	"github.com/json-iterator/go"
+	"github.com/17media/jsoniter"
 	"github.com/modern-go/reflect2"
 	"github.com/stretchr/testify/require"
 	"reflect"

--- a/extra/binary_as_string_codec.go
+++ b/extra/binary_as_string_codec.go
@@ -1,7 +1,7 @@
 package extra
 
 import (
-	"github.com/json-iterator/go"
+	"github.com/17media/jsoniter"
 	"github.com/modern-go/reflect2"
 	"unicode/utf8"
 	"unsafe"

--- a/extra/binary_as_string_codec_test.go
+++ b/extra/binary_as_string_codec_test.go
@@ -1,7 +1,7 @@
 package extra
 
 import (
-	"github.com/json-iterator/go"
+	"github.com/17media/jsoniter"
 	"github.com/stretchr/testify/require"
 	"testing"
 )

--- a/extra/fuzzy_decoder.go
+++ b/extra/fuzzy_decoder.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"unsafe"
 
-	"github.com/json-iterator/go"
+	"github.com/17media/jsoniter"
 	"github.com/modern-go/reflect2"
 )
 

--- a/extra/fuzzy_decoder_test.go
+++ b/extra/fuzzy_decoder_test.go
@@ -3,7 +3,7 @@ package extra
 import (
 	"testing"
 
-	"github.com/json-iterator/go"
+	"github.com/17media/jsoniter"
 	"github.com/stretchr/testify/require"
 )
 

--- a/extra/naming_strategy.go
+++ b/extra/naming_strategy.go
@@ -1,7 +1,7 @@
 package extra
 
 import (
-	"github.com/json-iterator/go"
+	"github.com/17media/jsoniter"
 	"strings"
 	"unicode"
 )

--- a/extra/naming_strategy_test.go
+++ b/extra/naming_strategy_test.go
@@ -1,7 +1,7 @@
 package extra
 
 import (
-	"github.com/json-iterator/go"
+	"github.com/17media/jsoniter"
 	"github.com/stretchr/testify/require"
 	"testing"
 )

--- a/extra/privat_fields.go
+++ b/extra/privat_fields.go
@@ -1,7 +1,7 @@
 package extra
 
 import (
-	"github.com/json-iterator/go"
+	"github.com/17media/jsoniter"
 	"strings"
 	"unicode"
 )

--- a/extra/private_fields_test.go
+++ b/extra/private_fields_test.go
@@ -1,7 +1,7 @@
 package extra
 
 import (
-	"github.com/json-iterator/go"
+	"github.com/17media/jsoniter"
 	"github.com/stretchr/testify/require"
 	"testing"
 )

--- a/extra/time_as_int64_codec.go
+++ b/extra/time_as_int64_codec.go
@@ -1,7 +1,7 @@
 package extra
 
 import (
-	"github.com/json-iterator/go"
+	"github.com/17media/jsoniter"
 	"time"
 	"unsafe"
 )

--- a/extra/time_as_int64_codec_test.go
+++ b/extra/time_as_int64_codec_test.go
@@ -1,7 +1,7 @@
 package extra
 
 import (
-	"github.com/json-iterator/go"
+	"github.com/17media/jsoniter"
 	"github.com/stretchr/testify/require"
 	"testing"
 	"time"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/json-iterator/go
+module github.com/17media/jsoniter
 
 go 1.12
 

--- a/misc_tests/jsoniter_array_test.go
+++ b/misc_tests/jsoniter_array_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/json-iterator/go"
+	"github.com/17media/jsoniter"
 	"github.com/stretchr/testify/require"
 )
 

--- a/misc_tests/jsoniter_bool_test.go
+++ b/misc_tests/jsoniter_bool_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/json-iterator/go"
+	"github.com/17media/jsoniter"
 	"github.com/stretchr/testify/require"
 )
 

--- a/misc_tests/jsoniter_float_test.go
+++ b/misc_tests/jsoniter_float_test.go
@@ -5,7 +5,7 @@ import (
 	"math"
 	"testing"
 
-	"github.com/json-iterator/go"
+	"github.com/17media/jsoniter"
 	"github.com/stretchr/testify/require"
 )
 

--- a/misc_tests/jsoniter_int_test.go
+++ b/misc_tests/jsoniter_int_test.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/json-iterator/go"
+	"github.com/17media/jsoniter"
 	"github.com/stretchr/testify/require"
 )
 

--- a/misc_tests/jsoniter_interface_test.go
+++ b/misc_tests/jsoniter_interface_test.go
@@ -2,7 +2,7 @@ package misc_tests
 
 import (
 	"encoding/json"
-	"github.com/json-iterator/go"
+	"github.com/17media/jsoniter"
 	"github.com/stretchr/testify/require"
 	"io"
 	"testing"

--- a/misc_tests/jsoniter_iterator_test.go
+++ b/misc_tests/jsoniter_iterator_test.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/json-iterator/go"
+	"github.com/17media/jsoniter"
 	"github.com/stretchr/testify/require"
 )
 

--- a/misc_tests/jsoniter_map_test.go
+++ b/misc_tests/jsoniter_map_test.go
@@ -5,7 +5,7 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/json-iterator/go"
+	"github.com/17media/jsoniter"
 	"github.com/stretchr/testify/require"
 	"strings"
 )

--- a/misc_tests/jsoniter_nested_test.go
+++ b/misc_tests/jsoniter_nested_test.go
@@ -2,7 +2,7 @@ package misc_tests
 
 import (
 	"encoding/json"
-	"github.com/json-iterator/go"
+	"github.com/17media/jsoniter"
 	"reflect"
 	"strings"
 	"testing"

--- a/misc_tests/jsoniter_null_test.go
+++ b/misc_tests/jsoniter_null_test.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"testing"
 
-	"github.com/json-iterator/go"
+	"github.com/17media/jsoniter"
 	"github.com/stretchr/testify/require"
 )
 

--- a/misc_tests/jsoniter_object_test.go
+++ b/misc_tests/jsoniter_object_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/json-iterator/go"
+	"github.com/17media/jsoniter"
 	"github.com/stretchr/testify/require"
 	"strings"
 	"time"

--- a/misc_tests/jsoniter_raw_message_test.go
+++ b/misc_tests/jsoniter_raw_message_test.go
@@ -2,7 +2,7 @@ package misc_tests
 
 import (
 	"encoding/json"
-	"github.com/json-iterator/go"
+	"github.com/17media/jsoniter"
 	"github.com/stretchr/testify/require"
 	"strings"
 	"testing"

--- a/skip_tests/jsoniter_skip_test.go
+++ b/skip_tests/jsoniter_skip_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/json-iterator/go"
+	"github.com/17media/jsoniter"
 	"github.com/stretchr/testify/require"
 )
 

--- a/skip_tests/skip_test.go
+++ b/skip_tests/skip_test.go
@@ -3,7 +3,7 @@ package skip_tests
 import (
 	"encoding/json"
 	"errors"
-	"github.com/json-iterator/go"
+	"github.com/17media/jsoniter"
 	"github.com/stretchr/testify/require"
 	"io"
 	"reflect"

--- a/type_tests/type_test.go
+++ b/type_tests/type_test.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/google/gofuzz"
-	"github.com/json-iterator/go"
+	"github.com/17media/jsoniter"
 	"reflect"
 	"strings"
 	"testing"

--- a/value_tests/error_test.go
+++ b/value_tests/error_test.go
@@ -1,7 +1,7 @@
 package test
 
 import (
-	"github.com/json-iterator/go"
+	"github.com/17media/jsoniter"
 	"github.com/stretchr/testify/require"
 	"reflect"
 	"testing"

--- a/value_tests/float_test.go
+++ b/value_tests/float_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/json-iterator/go"
+	"github.com/17media/jsoniter"
 	"github.com/stretchr/testify/require"
 	"strconv"
 	"testing"

--- a/value_tests/int_test.go
+++ b/value_tests/int_test.go
@@ -3,7 +3,7 @@ package test
 import (
 	"bytes"
 	"fmt"
-	"github.com/json-iterator/go"
+	"github.com/17media/jsoniter"
 	"github.com/stretchr/testify/require"
 	"strconv"
 	"testing"

--- a/value_tests/invalid_test.go
+++ b/value_tests/invalid_test.go
@@ -3,7 +3,7 @@ package test
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/json-iterator/go"
+	"github.com/17media/jsoniter"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"io"

--- a/value_tests/string_test.go
+++ b/value_tests/string_test.go
@@ -2,7 +2,7 @@ package test
 
 import (
 	"encoding/json"
-	"github.com/json-iterator/go"
+	"github.com/17media/jsoniter"
 	"testing"
 	"unicode/utf8"
 )

--- a/value_tests/value_test.go
+++ b/value_tests/value_test.go
@@ -3,7 +3,7 @@ package test
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/json-iterator/go"
+	"github.com/17media/jsoniter"
 	"github.com/modern-go/reflect2"
 	"github.com/stretchr/testify/require"
 	"testing"


### PR DESCRIPTION
## Description
Rename package name to 17media.

## Motivation and Context
For migrating go modules.
Module name and import path should be consistent.